### PR TITLE
tabs 组件下标active 类型修改

### DIFF
--- a/vant/tabs/index.js
+++ b/vant/tabs/index.js
@@ -39,7 +39,7 @@ create({
       observer: 'setLine'
     },
     active: {
-      type: null,
+      type: Number,
       value: 0
     },
     type: {


### PR DESCRIPTION
在使用 tabs组件时，发现没有显示活动tab的内容，查看源码发现是 active 类型错误。